### PR TITLE
Update Lezer to 0.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
+        "@lezer/common": "^0.16.0",
+        "@lezer/python": "^0.16.0",
         "chai-as-promised": "^7.1.1",
-        "lezer": "^0.13.5",
-        "lezer-python": "^0.13.7",
         "mochawesome": "^7.1.2",
         "ts-loader": "^8.0.11",
         "ts-node": "^9.1.1",
@@ -27,6 +27,36 @@
         "chai": "^4.2.0",
         "mocha": "^9.2.2",
         "webpack-cli": "^4.2.0"
+      }
+    },
+    "node_modules/@lezer/common": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.0.tgz",
+      "integrity": "sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A=="
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-0.16.0.tgz",
+      "integrity": "sha512-iE5f4flHlJ1g1clOStvXNLbORJoiW4Kytso6ubfYzHnaNo/eo5SKhxs4wv/rtvwZQeZrK3we8S9SyA7OGOoRKQ==",
+      "dependencies": {
+        "@lezer/common": "^0.16.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.3.tgz",
+      "integrity": "sha512-pau7um4eAw94BEuuShUIeQDTf3k4Wt6oIUOYxMmkZgDHdqtIcxWND4LRxi8nI9KuT4I1bXQv67BCapkxt7Ywqw==",
+      "dependencies": {
+        "@lezer/common": "^0.16.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-0.16.0.tgz",
+      "integrity": "sha512-jbcidwKGE1TwmozoHel6RwqHc6/gC8KAx8ZwFYUNcIuar20dQTGgyj6MVn85njhm2ZtejUJpTkVr5KS8KGh1CQ==",
+      "dependencies": {
+        "@lezer/highlight": "^0.16.0",
+        "@lezer/lr": "^0.16.0"
       }
     },
     "node_modules/@types/chai": {
@@ -1365,30 +1395,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/lezer": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/lezer/-/lezer-0.13.5.tgz",
-      "integrity": "sha512-cAiMQZGUo2BD8mpcz7Nv1TlKzWP7YIdIRrX41CiP5bk5t4GHxskOxWUx2iAOuHlz8dO+ivbuXr0J1bfHsWD+lQ==",
-      "deprecated": "This package has been replaced by @lezer/lr",
-      "dependencies": {
-        "lezer-tree": "^0.13.2"
-      }
-    },
-    "node_modules/lezer-python": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/lezer-python/-/lezer-python-0.13.7.tgz",
-      "integrity": "sha512-IoUdd88Hj2rdzV74xis5/NLWe69+GRe8wTI1z8ZIl/0IbyMAWEEvSHzAKqBGNGTuBIpBaW+l8awbW4gSZqrjIw==",
-      "deprecated": "This package has been replaced by @lezer/python",
-      "dependencies": {
-        "lezer": "^0.13.2"
-      }
-    },
-    "node_modules/lezer-tree": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/lezer-tree/-/lezer-tree-0.13.2.tgz",
-      "integrity": "sha512-15ZxW8TxVNAOkHIo43Iouv4zbSkQQ5chQHBpwXcD2bBFz46RB4jYLEEww5l1V0xyIx9U2clSyyrLes+hAUFrGQ==",
-      "deprecated": "This package has been replaced by @lezer/common"
     },
     "node_modules/loader-runner": {
       "version": "4.1.0",
@@ -2912,6 +2918,36 @@
     }
   },
   "dependencies": {
+    "@lezer/common": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.0.tgz",
+      "integrity": "sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A=="
+    },
+    "@lezer/highlight": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-0.16.0.tgz",
+      "integrity": "sha512-iE5f4flHlJ1g1clOStvXNLbORJoiW4Kytso6ubfYzHnaNo/eo5SKhxs4wv/rtvwZQeZrK3we8S9SyA7OGOoRKQ==",
+      "requires": {
+        "@lezer/common": "^0.16.0"
+      }
+    },
+    "@lezer/lr": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.3.tgz",
+      "integrity": "sha512-pau7um4eAw94BEuuShUIeQDTf3k4Wt6oIUOYxMmkZgDHdqtIcxWND4LRxi8nI9KuT4I1bXQv67BCapkxt7Ywqw==",
+      "requires": {
+        "@lezer/common": "^0.16.0"
+      }
+    },
+    "@lezer/python": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-0.16.0.tgz",
+      "integrity": "sha512-jbcidwKGE1TwmozoHel6RwqHc6/gC8KAx8ZwFYUNcIuar20dQTGgyj6MVn85njhm2ZtejUJpTkVr5KS8KGh1CQ==",
+      "requires": {
+        "@lezer/highlight": "^0.16.0",
+        "@lezer/lr": "^0.16.0"
+      }
+    },
     "@types/chai": {
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.14.tgz",
@@ -3948,27 +3984,6 @@
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true
-    },
-    "lezer": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/lezer/-/lezer-0.13.5.tgz",
-      "integrity": "sha512-cAiMQZGUo2BD8mpcz7Nv1TlKzWP7YIdIRrX41CiP5bk5t4GHxskOxWUx2iAOuHlz8dO+ivbuXr0J1bfHsWD+lQ==",
-      "requires": {
-        "lezer-tree": "^0.13.2"
-      }
-    },
-    "lezer-python": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/lezer-python/-/lezer-python-0.13.7.tgz",
-      "integrity": "sha512-IoUdd88Hj2rdzV74xis5/NLWe69+GRe8wTI1z8ZIl/0IbyMAWEEvSHzAKqBGNGTuBIpBaW+l8awbW4gSZqrjIw==",
-      "requires": {
-        "lezer": "^0.13.2"
-      }
-    },
-    "lezer-tree": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/lezer-tree/-/lezer-tree-0.13.2.tgz",
-      "integrity": "sha512-15ZxW8TxVNAOkHIo43Iouv4zbSkQQ5chQHBpwXcD2bBFz46RB4jYLEEww5l1V0xyIx9U2clSyyrLes+hAUFrGQ=="
     },
     "loader-runner": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@lezer/common": "^0.16.0",
+    "@lezer/python": "^0.16.0",
     "chai-as-promised": "^7.1.1",
-    "lezer": "^0.13.5",
-    "lezer-python": "^0.13.7",
     "mochawesome": "^7.1.2",
     "ts-loader": "^8.0.11",
     "ts-node": "^9.1.1",

--- a/parse-python.js
+++ b/parse-python.js
@@ -1,4 +1,4 @@
-const python = require('lezer-python');
+const python = require('@lezer/python');
 
 const input = "-1";
 

--- a/parser.ts
+++ b/parser.ts
@@ -1,5 +1,5 @@
-import {parser} from "lezer-python";
-import { TreeCursor} from "lezer-tree";
+import {parser} from "@lezer/python";
+import { TreeCursor} from "@lezer/common";
 import { Program, Expr, Stmt, UniOp, BinOp, Parameter, Type, FunDef, VarInit, Class, Literal, SourceLocation } from "./ast";
 import { NUM, BOOL, NONE, CLASS } from "./utils";
 import { stringifyTree } from "./treeprinter";

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -1,6 +1,6 @@
 // import * as mocha from 'mocha';
 // import {expect} from 'chai';
-// import { parser } from 'lezer-python';
+// import { parser } from '@lezer/python';
 // import { traverseExpr, traverseStmt, traverse, parse } from '../parser';
 
 // // We write tests for each function in parser.ts here. Each function gets its 

--- a/treeprinter.ts
+++ b/treeprinter.ts
@@ -1,4 +1,4 @@
-import { TreeCursor } from "lezer-tree" ;
+import { TreeCursor } from "@lezer/common" ;
 
 export function stringifyTree(t: TreeCursor, source: string, d: number): string {
     var str = "";


### PR DESCRIPTION
This isn't specifically related to my part of the project, but I remember a Piazza post that stated that we should use the most updated version of Lezer. https://piazza.com/class/l19qaxisql23rt?cid=316

I also get a little bugged whenever I see the deprecation warnings from "npm i", and thought this would be helpful to just prevent any bugs in the future.